### PR TITLE
Fix dynamic linkage on mac

### DIFF
--- a/R/02-flags.r
+++ b/R/02-flags.r
@@ -44,7 +44,7 @@ ldflags_string = function(static=FALSE)
       if (is.null(libfile))
         stop(paste("unable to dynamically link: can't find any of:", paste(libfiles, collapse=", ")))
 
-      flags = paste0("-L", float_libs_dir, " ", float_libs_dir, "/", libfile, " -Wl,-rpath ", float_libs_dir)
+      flags = paste0("-L", float_libs_dir, " -l", gsub("\\.\\w+$", "", libfile), " -Wl,-rpath,", float_libs_dir)
     }
     else
       flags = paste0("-L", float_libs_dir, " -l:float.so -Wl,-rpath=", float_libs_dir)


### PR DESCRIPTION
I think this should fix dynamic linkage for macOS, at least when using the apple clang compiler. Not sure how universal this solution is though, or whether it will work on the CRAN setups.

Fixes #40 .