### PR TITLE
Fix issues with omp+clang13

### DIFF
--- a/src/eigen.c
+++ b/src/eigen.c
@@ -1,10 +1,10 @@
 // Modified from the band package. Copyright (c) 2016 Drew Schmidt
 
-#include <float/slapack.h>
-
-#include "Rfloat.h"
 #include "safeomp.h"
+#include "Rfloat.h"
 #include "unroll.h"
+
+#include <float/slapack.h>
 
 
 static inline void reverse_vec(const float_len_t len, float *const x)

--- a/src/scale.c
+++ b/src/scale.c
@@ -1,9 +1,9 @@
 // Modified from the coop package. Copyright (c) 2015-2017 Drew Schmidt
 
+#include "safeomp.h"
 #include <Rdefines.h>
 #include <stdbool.h>
 
-#include "safeomp.h"
 #include "Rfloat.h"
 #include "unroll.h"
 


### PR DESCRIPTION
According to Prof. Ripley, the upcoming clang13 has issues compiling packages which include `<omp.h>` after some R headers such as `<Rincludes.h>` (which is part of `<R.h>`).

This PR should fix the issue. It's still on time for keeping the package safely on CRAN.