### PR TITLE
fix some errors caused by assigning rownames/names to wrong dimensions

### DIFF
--- a/R/bracket.r
+++ b/R/bracket.r
@@ -67,9 +67,9 @@ bracket_float32 = function(x, i, j, drop=TRUE)
   else
     d = bracket_float32_mat(x, i, j, drop=drop)
   
-  if (!is.null(rownames(x)))
+  if (!is.null(rownames(x)) & NROW(d) > 1 & NCOL(d) > 1)
     rownames(d) = rownames(x)[i]
-  if (!is.null(names(x)))
+  if (!is.null(names(x)) & length(d) > 1)
     names(d) = names(x)[j]
   
   float32(d)

--- a/R/bracket.r
+++ b/R/bracket.r
@@ -69,7 +69,7 @@ bracket_float32 = function(x, i, j, drop=TRUE)
   
   if (!is.null(rownames(x)) & NROW(d) > 1 & NCOL(d) > 1)
     rownames(d) = rownames(x)[i]
-  if (!is.null(names(x)) & length(d) > 1)
+  if (!is.null(names(x)) & !missing(j) & length(d) > 1)
     names(d) = names(x)[j]
   
   float32(d)


### PR DESCRIPTION
Hello,
I have observed that selecting individual elements, rows, or columns of a matrix with row names produces an error. A similar error occurs when selecting a vector or its sub-elements.

```
library(float)

x <- matrix(1:9, 3)
rownames(x) <- as.character(paste("row ", seq(3)))
colnames(x) <- as.character(paste("col ", seq(3)))

y <- as.float(x)

print(y[1, 1])      # -> Error in `rownames<-`(`*tmp*`, value = "row  1") : attempt to set 'rownames' on an object with no dimensions
print(y[1:2, 1])    # -> Error in `rownames<-`(`*tmp*`, value = "row  1") : attempt to set 'rownames' on an object with no dimensions
print(y[1, 1:2])    # -> Error in `rownames<-`(`*tmp*`, value = "row  1") : attempt to set 'rownames' on an object with no dimensions
print(y[1:2, 1:2])  # -> Error in `rownames<-`(`*tmp*`, value = "row  1") : attempt to set 'rownames' on an object with no dimensions


x <- 1:9
names(x) <- as.character(paste("ele ", seq(9)))

y <- as.float(x)
print(y)     # -> Error in names(d) = names(x)[j] :  'names' attribute [9] must be the same length as the vector [5]
print(y[1])  # -> Error in names(d) = names(x)[j] :  'names' attribute [9] must be the same length as the vector [5]
```

This pull request addresses these issues for me. However, I am unable to determine if it may have any unintended consequences.

Morover, I noticed that printing a vector still looks odd and should be checked.
```
x <- 1:9
names(x) <- as.character(paste("ele ", seq(9)))
y <- as.float(x)
print(y)
> # A float32 vector: 9
> ele  1 ele  2 ele  3 ele  4 ele  5       1      2      3      4      5  ...
```
