### PR TITLE
Do not hardcode LAPACK any flags

### DIFF
--- a/R/03-flags.r
+++ b/R/03-flags.r
@@ -10,40 +10,6 @@ get_os <- function()
   os
 }
 
-
-
-blas_ldflags_string = function()
-{
-  if (get_os() == "windows")
-  {
-    maj = as.numeric(version$major)
-    min = floor(as.numeric(version$minor))
-    if (maj < 4 || min <= 1)
-      ""
-    else
-      "-lblas"
-  }
-  else
-    blas_ldflags_nix() # defined by configure in R/02-libflags.r
-}
-
-lapack_ldflags_string = function()
-{
-  if (get_os() == "windows")
-  {
-    maj = as.numeric(version$major)
-    min = floor(as.numeric(version$minor))
-    if (maj < 4 || min <= 1)
-      ""
-    else
-      "-llapack"
-  }
-  else
-    lapack_ldflags_nix() # defined by configure in R/02-libflags.r
-}
-
-
-
 ldflags_string = function(static=FALSE)
 {
   install_path = "libs"
@@ -89,7 +55,7 @@ ldflags_string = function(static=FALSE)
 
 ldflags = function(static=FALSE)
 {
-  linalg_flags = paste(lapack_ldflags_string(), blas_ldflags_string())
+  linalg_flags = "$(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)"
   float_flags = ldflags_string(static=static)
   flags = paste(float_flags, linalg_flags)
   


### PR DESCRIPTION
This should fix errors like this: https://github.com/r-universe/cran/actions/runs/7619266054/job/20756957057. The problem here is that the LAPACK configuration on the server that has built float could be different than on the user machine.

The portable way for an R package to link to LAPACK/BLAS is `PKG_LIBS= $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)` in the Makevars, verbatim. This works on any platform. There is no for `float` to try to resolve this.